### PR TITLE
Changing plonk_variable template parameter type

### DIFF
--- a/include/nil/blueprint/curves/addition.hpp
+++ b/include/nil/blueprint/curves/addition.hpp
@@ -55,13 +55,13 @@ namespace nil {
                 CurveType, 11>::result_type
                 handle_native_curve_unified_addition_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>> &vectors,
+                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>> &vectors,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
                 using component_type = components::unified_addition<ArithmetizationType, CurveType, 11>;
@@ -86,7 +86,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_curve_addition_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
@@ -114,7 +114,7 @@ namespace nil {
                         typename component_type::result_type res =
                             detail::handle_native_curve_unified_addition_component<BlueprintFieldType, ArithmetizationParams, operating_curve_type>(
                                 operand0, operand1, frame.vectors, bp, assignment, start_row);
-                        std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> res_vector = {res.X, res.Y};
+                        std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> res_vector = {res.X, res.Y};
                         frame.vectors[inst] = res_vector;
                     } else {
                         UNREACHABLE("non-native pallas is undefined");

--- a/include/nil/blueprint/curves/multiplication.hpp
+++ b/include/nil/blueprint/curves/multiplication.hpp
@@ -55,13 +55,13 @@ namespace nil {
                 CurveType, 15>::result_type
                 handle_native_curve_non_native_scalar_multiplication_component(
                     llvm::Value *operand_curve, llvm::Value *operand_field,
-                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>> &vectors,
+                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>> &vectors,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using ArithmetizationType = crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
                 using component_type = components::curve_element_variable_base_scalar_mul<
@@ -87,7 +87,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_curve_multiplication_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
@@ -140,7 +140,7 @@ namespace nil {
                         typename component_type::result_type res =
                             detail::handle_native_curve_non_native_scalar_multiplication_component<BlueprintFieldType, ArithmetizationParams, operating_curve_type>(
                                 operand_curve, operand_field, frame.vectors, bp, assignment, start_row);
-                        std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> res_vector = {res.X, res.Y};
+                        std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> res_vector = {res.X, res.Y};
                         frame.vectors[inst] = res_vector;
                     } else {
                         UNREACHABLE("non-native pallas multiplication is not implemented");

--- a/include/nil/blueprint/curves/subtraction.hpp
+++ b/include/nil/blueprint/curves/subtraction.hpp
@@ -52,7 +52,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_curve_subtraction_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/fields/addition.hpp
+++ b/include/nil/blueprint/fields/addition.hpp
@@ -56,13 +56,13 @@ namespace nil {
                 BlueprintFieldType, 3, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_native_field_addition_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &variables,
+                    typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using component_type = components::addition<
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
@@ -82,13 +82,13 @@ namespace nil {
                 OperatingFieldType, 9, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_non_native_field_addition_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>> &vectors,
+                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>> &vectors,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
                 using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
 
                 using component_type = components::addition<
@@ -118,7 +118,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_field_addition_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
@@ -187,7 +187,7 @@ namespace nil {
                                                    operand0, operand1, frame.vectors, bp, assignment, start_row)
                                                    .output;
 
-                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>(
+                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>(
                             std::begin(component_result), std::end(component_result));
                     }
 

--- a/include/nil/blueprint/fields/division.hpp
+++ b/include/nil/blueprint/fields/division.hpp
@@ -55,13 +55,13 @@ namespace nil {
                 BlueprintFieldType, 4, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_native_field_division_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &variables,
+                    typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using component_type = components::division<
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
@@ -80,7 +80,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_field_division_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/fields/multiplication.hpp
+++ b/include/nil/blueprint/fields/multiplication.hpp
@@ -56,13 +56,13 @@ namespace nil {
                 BlueprintFieldType, 3, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_native_field_multiplication_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &variables,
+                    std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using component_type = components::multiplication<
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
@@ -82,13 +82,13 @@ namespace nil {
                 OperatingFieldType, 9, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_non_native_field_multiplication_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>> &vectors,
+                    typename std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>> &vectors,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
                 using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
 
                 using component_type = components::multiplication<
@@ -118,7 +118,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_field_multiplication_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
@@ -187,7 +187,7 @@ namespace nil {
                                                    operand0, operand1, frame.vectors, bp, assignment, start_row)
                                                    .output;
 
-                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>(
+                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>(
                             std::begin(component_result), std::end(component_result));
                     }
 

--- a/include/nil/blueprint/fields/subtraction.hpp
+++ b/include/nil/blueprint/fields/subtraction.hpp
@@ -56,13 +56,13 @@ namespace nil {
                 BlueprintFieldType, 3, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_native_field_subtraction_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &variables,
+                    std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
                 using component_type = components::subtraction<
                     crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>,
@@ -82,13 +82,13 @@ namespace nil {
                 OperatingFieldType, 9, basic_non_native_policy<BlueprintFieldType>>::result_type
                 handle_non_native_field_subtraction_component(
                     llvm::Value *operand0, llvm::Value *operand1,
-                    std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>> &vectors,
+                    std::map<const llvm::Value *, std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>> &vectors,
                     circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
                     assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                         &assignment,
                     std::uint32_t start_row) {
 
-                using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+                using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
                 using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
 
                 using component_type = components::subtraction<
@@ -118,7 +118,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_field_subtraction_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
@@ -187,7 +187,7 @@ namespace nil {
                                                    operand0, operand1, frame.vectors, bp, assignment, start_row)
                                                    .output;
 
-                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<BlueprintFieldType>>(
+                        frame.vectors[inst] = std::vector<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>>(
                             std::begin(component_result), std::end(component_result));
                     }
 

--- a/include/nil/blueprint/integers/addition.hpp
+++ b/include/nil/blueprint/integers/addition.hpp
@@ -44,7 +44,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_integer_addition_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/integers/division.hpp
+++ b/include/nil/blueprint/integers/division.hpp
@@ -45,7 +45,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_integer_division_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/integers/multiplication.hpp
+++ b/include/nil/blueprint/integers/multiplication.hpp
@@ -45,7 +45,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_integer_multiplication_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/integers/subtraction.hpp
+++ b/include/nil/blueprint/integers/subtraction.hpp
@@ -45,7 +45,7 @@ namespace nil {
         template<typename BlueprintFieldType, typename ArithmetizationParams>
         void handle_integer_subtraction_component(
             const llvm::Instruction *inst,
-            stack_frame<crypto3::zk::snark::plonk_variable<BlueprintFieldType>> &frame,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
             circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,

--- a/include/nil/blueprint/parser.hpp
+++ b/include/nil/blueprint/parser.hpp
@@ -80,7 +80,7 @@ namespace nil {
 
             using ArithmetizationType =
                 crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>;
-            using var = crypto3::zk::snark::plonk_variable<BlueprintFieldType>;
+            using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
             circuit<ArithmetizationType> bp;
             assignment<ArithmetizationType> assignmnt;


### PR DESCRIPTION
Closes #89

This is the second time we merge this functionality to master (previous: https://github.com/NilFoundation/zkllvm-assigner/pull/90). After we merged the PR last time, I force-pushed the master, since not all of dependencies were ready to support the functionality.