### PR TITLE
Comparison processing added

### DIFF
--- a/include/nil/blueprint/comparison/comparison.hpp
+++ b/include/nil/blueprint/comparison/comparison.hpp
@@ -1,0 +1,103 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2023 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_ASSIGNER_COMPARISON_HPP
+#define CRYPTO3_ASSIGNER_COMPARISON_HPP
+
+#include "llvm/IR/Type.h"
+#include "llvm/IR/TypeFinder.h"
+#include "llvm/IR/TypedPointerType.h"
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/components/algebra/fields/plonk/non_native/comparison_flag.hpp>
+
+#include <nil/blueprint/asserts.hpp>
+#include <nil/blueprint/stack.hpp>
+
+namespace nil {
+    namespace blueprint {
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        typename crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>
+            handle_comparison_component(
+                llvm::CmpInst::Predicate p,
+                const typename crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type> &x,
+                const typename crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type> &y,
+                std::size_t Bitness,
+                circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+                assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                    &assignment,
+                std::uint32_t start_row,
+                std::size_t &public_input_idx) {
+
+            using component_type = components::comparison_flag<
+                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>, 3>;
+
+            nil::blueprint::components::detail::comparison_mode Mode;
+
+            switch (p) {
+                case llvm::CmpInst::ICMP_EQ:
+                    Mode = nil::blueprint::components::detail::comparison_mode::FLAG;
+                    break;
+                case llvm::CmpInst::ICMP_NE:{
+                    bool res = (var_value(assignment, x) != var_value(assignment, y));
+                    assignment.public_input(0, public_input_idx) = res;
+                    using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+                    return var(0, public_input_idx++, false, var::column_type::public_input);
+                    break;
+                }
+                case llvm::CmpInst::ICMP_SGE:
+                case llvm::CmpInst::ICMP_UGE:
+                    Mode = nil::blueprint::components::detail::comparison_mode::GREATER_EQUAL;
+                    break;
+                case llvm::CmpInst::ICMP_SGT:
+                case llvm::CmpInst::ICMP_UGT:
+                    Mode = nil::blueprint::components::detail::comparison_mode::GREATER_THAN;
+                    break;
+                case llvm::CmpInst::ICMP_SLE:
+                case llvm::CmpInst::ICMP_ULE:
+                    Mode = nil::blueprint::components::detail::comparison_mode::LESS_EQUAL;
+                    break;
+                case llvm::CmpInst::ICMP_SLT:
+                case llvm::CmpInst::ICMP_ULT:
+                    Mode = nil::blueprint::components::detail::comparison_mode::LESS_THAN;
+                    break;
+                default:
+                    UNREACHABLE("Unsupported icmp predicate");
+                    break;
+            }
+
+            std::size_t bitness = Bitness?Bitness:BlueprintFieldType::value_bits - 1;
+
+            component_type component_instance = component_type({0, 1, 2}, {0}, {0}, bitness, Mode);
+
+            components::generate_circuit(component_instance, bp, assignment, {x, y}, start_row);
+            return components::generate_assignments(component_instance, assignment, {x, y}, start_row).flag;
+        }
+
+    }    // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_ASSIGNER_COMPARISON_HPP

--- a/include/nil/blueprint/integers/bit_shift.hpp
+++ b/include/nil/blueprint/integers/bit_shift.hpp
@@ -1,0 +1,107 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2022 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2022 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_ASSIGNER_INTEGER_BIT_SHIFT_HPP
+#define CRYPTO3_ASSIGNER_INTEGER_BIT_SHIFT_HPP
+
+#include "llvm/IR/Type.h"
+#include "llvm/IR/TypeFinder.h"
+#include "llvm/IR/TypedPointerType.h"
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/components/algebra/fields/plonk/bit_shift_constant.hpp>
+
+#include <nil/blueprint/asserts.hpp>
+#include <nil/blueprint/stack.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace detail {
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        typename components::bit_shift_constant<
+        crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>, 9>::result_type
+            handle_native_field_bit_shift_constant_component(
+            std::size_t Bitness,
+            llvm::Value *operand0, llvm::Value *operand1,
+            typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment,
+            std::uint32_t start_row,
+            typename nil::blueprint::components::detail::bit_shift_mode left_or_right) {
+
+            using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+            var x = variables[operand0];
+            var shift_var = variables[operand1];
+
+            //TODO: Shift should be input of the component, not as done there
+            std::size_t Shift = std::size_t(typename BlueprintFieldType::integral_type(var_value(assignment, shift_var).data));
+
+            using component_type = nil::blueprint::components::bit_shift_constant<
+                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>, 9>;
+
+            using nil::blueprint::components::detail::bit_shift_mode;
+
+
+            component_type component_instance({0, 1, 2, 3, 4, 5, 6, 7, 8}, {0}, {0}, Bitness, Shift, left_or_right);
+
+
+            components::generate_circuit(component_instance, bp, assignment, {x}, start_row);
+            return components::generate_assignments(component_instance, assignment, {x}, start_row);
+
+            }
+        }    // namespace detail
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        void handle_integer_bit_shift_constant_component(
+            const llvm::Instruction *inst,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment,
+            std::uint32_t start_row,
+            typename nil::blueprint::components::detail::bit_shift_mode left_or_right) {
+
+            using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
+
+            llvm::Value *operand0 = inst->getOperand(0);
+            llvm::Value *operand1 = inst->getOperand(1);
+
+            ASSERT(inst->getOperand(0)->getType()->getPrimitiveSizeInBits() == inst->getOperand(1)->getType()->getPrimitiveSizeInBits());
+
+            std::size_t bitness = inst->getOperand(0)->getType()->getPrimitiveSizeInBits();
+
+            frame.scalars[inst] = detail::handle_native_field_bit_shift_constant_component<BlueprintFieldType, ArithmetizationParams>(
+                                bitness, operand0, operand1, frame.scalars, bp, assignment, start_row, left_or_right).output;
+
+        }
+
+    }    // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_ASSIGNER_INTEGER_BIT_SHIFT_HPP

--- a/include/nil/blueprint/integers/division_remainder.hpp
+++ b/include/nil/blueprint/integers/division_remainder.hpp
@@ -1,0 +1,106 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2022 Mikhail Komarov <nemo@nil.foundation>
+// Copyright (c) 2022 Nikita Kaskov <nbering@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+
+#ifndef CRYPTO3_ASSIGNER_INTEGER_DIVISION_REMAINDER_HPP
+#define CRYPTO3_ASSIGNER_INTEGER_DIVISION_REMAINDER_HPP
+
+#include "llvm/IR/Type.h"
+#include "llvm/IR/TypeFinder.h"
+#include "llvm/IR/TypedPointerType.h"
+
+#include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
+
+#include <nil/blueprint/components/algebra/fields/plonk/non_native/division_remainder.hpp>
+
+#include <nil/blueprint/asserts.hpp>
+#include <nil/blueprint/stack.hpp>
+
+namespace nil {
+    namespace blueprint {
+        namespace detail {
+
+
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        typename components::division_remainder<
+        crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>, 9>::result_type
+            handle_native_field_division_remainder_component(
+            std::size_t Bitness,
+            llvm::Value *operand0, llvm::Value *operand1,
+            typename std::map<const llvm::Value *, crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &variables,
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment,
+            std::uint32_t start_row) {
+
+            using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
+
+            using component_type = components::division_remainder<
+                crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>, 9>;
+            component_type component_instance({0, 1, 2, 3, 4, 5, 6, 7, 8}, {0}, {0}, Bitness, true);
+
+            var x = variables[operand0];
+            var y = variables[operand1];
+
+            components::generate_circuit(component_instance, bp, assignment, {x, y}, start_row);
+            return components::generate_assignments(component_instance, assignment, {x, y}, start_row);
+
+            }
+        }    // namespace detail
+
+        template<typename BlueprintFieldType, typename ArithmetizationParams>
+        void handle_integer_division_remainder_component(
+            const llvm::Instruction *inst,
+            stack_frame<crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>> &frame,
+            circuit<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>> &bp,
+            assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
+                &assignment,
+            std::uint32_t start_row,
+            bool is_division) {
+
+            using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
+
+            llvm::Value *operand0 = inst->getOperand(0);
+            llvm::Value *operand1 = inst->getOperand(1);
+
+            ASSERT(inst->getOperand(0)->getType()->getPrimitiveSizeInBits() == inst->getOperand(1)->getType()->getPrimitiveSizeInBits());
+
+            std::size_t bitness = inst->getOperand(0)->getType()->getPrimitiveSizeInBits();
+
+            if (is_division) {
+                frame.scalars[inst] = detail::handle_native_field_division_remainder_component<BlueprintFieldType, ArithmetizationParams>(
+                                bitness, operand0, operand1, frame.scalars, bp, assignment, start_row).quotient;
+            }
+            else {
+                frame.scalars[inst] = detail::handle_native_field_division_remainder_component<BlueprintFieldType, ArithmetizationParams>(
+                                bitness, operand0, operand1, frame.scalars, bp, assignment, start_row).remainder;
+            }
+
+        }
+
+    }    // namespace blueprint
+}    // namespace nil
+
+#endif    // CRYPTO3_ASSIGNER_INTEGER_DIVISION_REMAINDER_HPP

--- a/include/nil/blueprint/parser.hpp
+++ b/include/nil/blueprint/parser.hpp
@@ -56,6 +56,7 @@
 #include <nil/blueprint/integers/subtraction.hpp>
 #include <nil/blueprint/integers/multiplication.hpp>
 #include <nil/blueprint/integers/division.hpp>
+#include <nil/blueprint/integers/division_remainder.hpp>
 
 #include <nil/blueprint/comparison/comparison.hpp>
 
@@ -109,7 +110,7 @@ namespace nil {
                 const std::vector<var> &rhs = frame.vectors[inst->getOperand(1)];
                 ASSERT(lhs.size() == rhs.size());
                 std::vector<var> res;
-                
+
                 // Todo: this either isn't a proper way to handle vector element size or it's not implemented correctly
                 std::size_t bitness = inst->getOperand(0)->getType()->getScalarType()->getPrimitiveSizeInBits();
                 for (size_t i = 0; i < lhs.size(); ++i) {
@@ -284,7 +285,7 @@ namespace nil {
 
                         auto &block_arg0 = frame.vectors[inst->getOperand(0)];
                         auto &block_arg1 = frame.vectors[inst->getOperand(1)];
-                        
+
                         std::array<var, 128> input_block_vars;
 
                         std::copy(block_arg0.begin(), block_arg0.end(), input_block_vars.begin());
@@ -468,7 +469,24 @@ namespace nil {
                             UNREACHABLE("cmul opcode is defined only for curveTy * fieldTy");
                         }
                     }
-                    case llvm::Instruction::UDiv:
+                    case llvm::Instruction::UDiv: {
+                        if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
+                            handle_integer_division_remainder_component<BlueprintFieldType, ArithmetizationParams>(
+                                inst, frame, bp, assignmnt, start_row, true);
+                            return inst->getNextNonDebugInstruction();
+                        } else {
+                            UNREACHABLE("UDiv opcode is defined only for integerTy");
+                        }
+                    }
+                    case llvm::Instruction::URem: {
+                        if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
+                            handle_integer_division_remainder_component<BlueprintFieldType, ArithmetizationParams>(
+                                inst, frame, bp, assignmnt, start_row, false);
+                            return inst->getNextNonDebugInstruction();
+                        } else {
+                            UNREACHABLE("URem opcode is defined only for integerTy");
+                        }
+                    }
                     case llvm::Instruction::SDiv: {
 
                         if (inst->getOperand(0)->getType()->isIntegerTy()) {

--- a/include/nil/blueprint/parser.hpp
+++ b/include/nil/blueprint/parser.hpp
@@ -57,6 +57,7 @@
 #include <nil/blueprint/integers/multiplication.hpp>
 #include <nil/blueprint/integers/division.hpp>
 #include <nil/blueprint/integers/division_remainder.hpp>
+#include <nil/blueprint/integers/bit_shift.hpp>
 
 #include <nil/blueprint/comparison/comparison.hpp>
 
@@ -485,6 +486,26 @@ namespace nil {
                             return inst->getNextNonDebugInstruction();
                         } else {
                             UNREACHABLE("URem opcode is defined only for integerTy");
+                        }
+                    }
+                    case llvm::Instruction::Shl: {
+                        if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
+                            handle_integer_bit_shift_constant_component<BlueprintFieldType, ArithmetizationParams>(
+                                inst, frame, bp, assignmnt, start_row,
+                                        nil::blueprint::components::detail::bit_shift_mode::LEFT);
+                            return inst->getNextNonDebugInstruction();
+                        } else {
+                            UNREACHABLE("shl opcode is defined only for integerTy");
+                        }
+                    }
+                    case llvm::Instruction::LShr: {
+                        if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
+                            handle_integer_bit_shift_constant_component<BlueprintFieldType, ArithmetizationParams>(
+                                inst, frame, bp, assignmnt, start_row,
+                                        nil::blueprint::components::detail::bit_shift_mode::RIGHT);
+                            return inst->getNextNonDebugInstruction();
+                        } else {
+                            UNREACHABLE("LShr opcode is defined only for integerTy");
                         }
                     }
                     case llvm::Instruction::SDiv: {

--- a/include/nil/blueprint/public_input.hpp
+++ b/include/nil/blueprint/public_input.hpp
@@ -175,7 +175,7 @@ namespace nil {
                     }
                     return result;
                 }
-            
+
                 default:
                     UNREACHABLE("unsupported field operand type");
             }
@@ -204,7 +204,7 @@ namespace nil {
                     numlen = value.as_string().size();
                     if (numlen > buflen - 1) {
                         std::cerr << "value " << value.as_string() << " exceeds buffer size (" << buflen - 1 << ")\n";
-                        UNREACHABLE("value size exceeds buffer size"); 
+                        UNREACHABLE("value size exceeds buffer size");
                     }
                     value.as_string().copy(buf, numlen);
                     buf[numlen] = '\0';
@@ -277,7 +277,7 @@ namespace nil {
 
             std::vector<var> put_field_into_assignmnt (std::vector<typename BlueprintFieldType::value_type> input) {
 
-                std::vector<var> res; 
+                std::vector<var> res;
 
                 for (std::size_t i = 0; i < input.size(); i++) {
                     assignmnt.public_input(0, public_input_idx) = input[i];
@@ -315,7 +315,7 @@ namespace nil {
                     numlen = value.as_string().size();
                     if (numlen > buflen - 1) {
                         std::cerr << "value " << value.as_string() << " exceeds buffer size (" << buflen - 1 << ")\n";
-                        UNREACHABLE("value size exceeds buffer size"); 
+                        UNREACHABLE("value size exceeds buffer size");
                     }
                     value.as_string().copy(buf, numlen);
                     buf[numlen] = '\0';
@@ -341,7 +341,7 @@ namespace nil {
                 llvm::GaloisFieldKind arg_field_type;
                 if (llvm::isa<llvm::GaloisFieldType>(field_type)) {
                     arg_field_type = llvm::cast<llvm::GaloisFieldType>(field_type)->getFieldKind();
-                } 
+                }
                 else {UNREACHABLE("public input reader take_field can handle only fields");}
                 if (value.at("field").is_double()) {
                     error =
@@ -441,13 +441,13 @@ namespace nil {
                         } else {
                             UNREACHABLE("curve elemein in the array is not json object");
                         }
-                    } 
+                    }
                     else if(elem_type->isFieldTy()){
                         if (json_arr[i].is_object()) {
                             elem_value = process_field(elem_type, json_arr[i].as_object());
                             if (elem_value.size() == 1) {
                                 frame.memory.back().store_var(elem_value[0], i);
-                            } 
+                            }
                             else {
                                 frame.memory.back().store_vector(elem_value, i);
                             }
@@ -462,7 +462,7 @@ namespace nil {
                         }
                         if (elem_len == 1) {
                             frame.memory.back().store_var(elem_value[0], i);
-                        } 
+                        }
                         else {
                             frame.memory.back().store_vector(elem_value, i);
                         }


### PR DESCRIPTION
comparison_flag component is used for all `icmp` cases except from `icmp::ne`. Here is an issue on this topic: https://github.com/NilFoundation/zkllvm/issues/187
