### PR TITLE
Move bit_shift_mode and bit_composition_mode to correct namespace

### DIFF
--- a/include/nil/blueprint/integers/bit_de_composition.hpp
+++ b/include/nil/blueprint/integers/bit_de_composition.hpp
@@ -58,7 +58,7 @@ namespace nil {
 
             using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
-            using mode = nil::blueprint::components::detail::bit_composition_mode;
+            using mode = nil::blueprint::components::bit_composition_mode;
 
             var component_input = variables[operand0];
             var sig_bit_var = variables[operand_sig_bit]; // TODO should be input of blueprint component, not as there
@@ -96,7 +96,7 @@ namespace nil {
             using component_type = nil::blueprint::components::bit_composition<
                 crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>;
 
-            using mode = nil::blueprint::components::detail::bit_composition_mode;
+            using mode = nil::blueprint::components::bit_composition_mode;
 
             std::vector<var> component_input = vectors[operand0];
             component_input.insert(component_input.end(), vectors[operand1].begin(), vectors[operand1].end());

--- a/include/nil/blueprint/integers/bit_shift.hpp
+++ b/include/nil/blueprint/integers/bit_shift.hpp
@@ -52,7 +52,7 @@ namespace nil {
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
             std::uint32_t start_row,
-            typename nil::blueprint::components::detail::bit_shift_mode left_or_right) {
+            typename nil::blueprint::components::bit_shift_mode left_or_right) {
 
             using var = crypto3::zk::snark::plonk_variable<typename BlueprintFieldType::value_type>;
 
@@ -65,7 +65,7 @@ namespace nil {
             using component_type = nil::blueprint::components::bit_shift_constant<
                 crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>;
 
-            using nil::blueprint::components::detail::bit_shift_mode;
+            using nil::blueprint::components::bit_shift_mode;
 
 
             component_type component_instance({0, 1, 2, 3, 4, 5, 6, 7, 8}, {0}, {0}, Bitness, Shift, left_or_right);
@@ -85,7 +85,7 @@ namespace nil {
             assignment<crypto3::zk::snark::plonk_constraint_system<BlueprintFieldType, ArithmetizationParams>>
                 &assignment,
             std::uint32_t start_row,
-            typename nil::blueprint::components::detail::bit_shift_mode left_or_right) {
+            typename nil::blueprint::components::bit_shift_mode left_or_right) {
 
             using non_native_policy_type = basic_non_native_policy<BlueprintFieldType>;
 

--- a/include/nil/blueprint/parser.hpp
+++ b/include/nil/blueprint/parser.hpp
@@ -671,7 +671,7 @@ namespace nil {
                         if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
                             handle_integer_bit_shift_constant_component<BlueprintFieldType, ArithmetizationParams>(
                                 inst, frame, bp, assignmnt, start_row,
-                                        nil::blueprint::components::detail::bit_shift_mode::LEFT);
+                                        nil::blueprint::components::bit_shift_mode::LEFT);
                             return inst->getNextNonDebugInstruction();
                         } else {
                             UNREACHABLE("shl opcode is defined only for integerTy");
@@ -681,7 +681,7 @@ namespace nil {
                         if (inst->getOperand(0)->getType()->isIntegerTy() && inst->getOperand(1)->getType()->isIntegerTy()) {
                             handle_integer_bit_shift_constant_component<BlueprintFieldType, ArithmetizationParams>(
                                 inst, frame, bp, assignmnt, start_row,
-                                        nil::blueprint::components::detail::bit_shift_mode::RIGHT);
+                                        nil::blueprint::components::bit_shift_mode::RIGHT);
                             return inst->getNextNonDebugInstruction();
                         } else {
                             UNREACHABLE("LShr opcode is defined only for integerTy");


### PR DESCRIPTION
There were changes in
https://github.com/NilFoundation/zkllvm-blueprint/commit/d6177ec59cc35467e09fb2a8c03f62c3cc428d88 that moved bit_composition_mode and bit_shift_mode from the detail:: namespace up one level. This breaks comipation of the assigner, since it hasn't been updated accordingly.

I've found this while experimenting with zkllvm with all submodules updated to master. Since submodules are eventually integrated together, I guess this pull request may be useful.