### PR TITLE
Memory Management: fix handling of structs in loads and stores

### DIFF
--- a/include/nil/blueprint/layout_resolver.hpp
+++ b/include/nil/blueprint/layout_resolver.hpp
@@ -127,10 +127,13 @@ namespace nil {
                 if (type_cache.find(type) == type_cache.end())
                     resolve_type<BlueprintFieldType>(type);
                 auto *type_record = &type_cache[type];
+                unsigned offset = 0;
                 for (unsigned i = 0; i < gep_indices.size() - 1; ++i) {
-                    type_record = &type_cache[type_record->indices[gep_indices[i]].type];
+                    auto layout_element = type_record->indices[gep_indices[i]];
+                    offset += layout_element.idx;
+                    type_record = &type_cache[layout_element.type];
                 }
-                return type_record->indices[gep_indices.back()].idx;
+                return offset + type_record->indices[gep_indices.back()].idx;
             }
 
             unsigned get_type_size(llvm::Type *type) {


### PR DESCRIPTION
This PR provides some fixes to the handling of loads and stores of aggregate types, which were not handled correctly at the moment.

The first commit fixes the loading and storing of aggregate types in the program_memory, similar to the special case of vector loads. For vector stores, we have not added any handling, as they were not handled atm anyway.
The second commit fixes the flat index calculation for multidimensional indexing, e.g., the case where we have an array inside of a struct.