### PR TITLE
Memory Management: handle return values that are AggregateTypes

### DIFF
--- a/include/nil/blueprint/parser.hpp
+++ b/include/nil/blueprint/parser.hpp
@@ -1124,7 +1124,6 @@ namespace nil {
                                 memcpy(allocated_copy, ret_ptr, size);
                                 auto &upper_frame_variables = call_stack.top().scalars;
 
-                                upper_frame_variables[extracted_frame.caller] = extracted_frame.scalars[ret_val];
                                 upper_frame_variables[extracted_frame.caller] = put_into_assignment(allocated_copy);
                             } else {
                                 auto &upper_frame_variables = call_stack.top().scalars;

--- a/include/nil/blueprint/stack.hpp
+++ b/include/nil/blueprint/stack.hpp
@@ -49,6 +49,8 @@ namespace nil {
             std::map<const llvm::Value *, VarType> scalars;
             std::map<const llvm::Value *, std::vector<VarType>> vectors;
             const llvm::CallInst *caller;
+            // a pointer to the memory allocated for the return value of our callee
+            ptr_type ret_ptr;
         };
 
     }    // namespace blueprint


### PR DESCRIPTION
This PR fixes the handling of return values from function calls that are AggregateTypes.

The existing handling has some edge cases where the copying of the structs does not work correctly, since the offsets of the values in the aggregate types can be overwritten by the call to `add_cells` in some cases, breaking the following `memcpy` call.

Our solution to handle this is to allocate the memory for the aggregate return type already at the caller site, so we have a reserved memory region with correct alignment, and then copying the returned struct there.