### PR TITLE
Update version of reusable-handle-syncwith in CI workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   handle-syncwith:
     name: Call Reusable SyncWith Handler
-    uses: NilFoundation/ci-cd/.github/workflows/reusable-handle-syncwith.yml@v1.1.2
+    uses: NilFoundation/ci-cd/.github/workflows/reusable-handle-syncwith.yml@v1.2.1
     with:
       ci-cd-ref: 'v1.1.2'
     secrets: inherit


### PR DESCRIPTION
This will allow to use backticks in PR titles with "SyncWith". There was a bug with backticks and now it's fixed.