### PR TITLE
Implement PRINT_LLVM_OBJECT macro

### DIFF
--- a/include/nil/blueprint/assigner.hpp
+++ b/include/nil/blueprint/assigner.hpp
@@ -54,6 +54,7 @@
 
 #include <nil/blueprint/logger.hpp>
 #include <nil/blueprint/layout_resolver.hpp>
+#include <nil/blueprint/macros.hpp>
 #include <nil/blueprint/input_reader.hpp>
 #include <nil/blueprint/memory.hpp>
 #include <nil/blueprint/non_native_marshalling.hpp>
@@ -349,7 +350,8 @@ namespace nil {
                             memory.store(ptr++, globals[constant]);
                             continue;
                         }
-                        UNREACHABLE("Unsupported pointer initialization!");
+                        LLVM_PRINT(constant, str);
+                        UNREACHABLE("Unsupported pointer initialization: " + str);
                     }
                     if (!type->isAggregateType() && !type->isVectorTy()) {
                         column_type<BlueprintFieldType> marshalled_field_val = marshal_field_val<BlueprintFieldType>(constant);
@@ -827,7 +829,8 @@ namespace nil {
                     memory.store(ptr, zero_var);
                     globals[global] = put_constant_into_assignment(ptr);
                 } else {
-                    UNREACHABLE("Unhandled global variable");
+                    LLVM_PRINT(global, str);
+                    UNREACHABLE("Unhandled global variable: " + str);
                 }
             }
 
@@ -914,8 +917,10 @@ namespace nil {
                         }
                         break;
                     }
-                    default:
-                        UNREACHABLE(std::string("Unhandled constant expression: ") + expr->getOpcodeName());
+                    default: {
+                        LLVM_PRINT(expr, str);
+                        UNREACHABLE("Unhandled constant expression: " + str);
+                    }
                     }
                 } else if (auto addr = llvm::dyn_cast<llvm::BlockAddress>(c)) {
                     frame.scalars[c] = labels[addr->getBasicBlock()];
@@ -1191,7 +1196,8 @@ namespace nil {
                         else if (cmp_type->isCurveTy())
                             handle_curve_cmp(cmp_inst, frame);
                         else {
-                            UNREACHABLE("Unsupported icmp operand type");
+                            LLVM_PRINT(cmp_type, str);
+                            UNREACHABLE("Unsupported icmp operand type: " + str);
                         }
                         return inst->getNextNonDebugInstruction();
                     }

--- a/include/nil/blueprint/logger.hpp
+++ b/include/nil/blueprint/logger.hpp
@@ -26,6 +26,8 @@
 #ifndef ZKLLVM_ASSIGNER_INCLUDE_NIL_BLUEPRINT_LOGGER_HPP_
 #define ZKLLVM_ASSIGNER_INCLUDE_NIL_BLUEPRINT_LOGGER_HPP_
 
+#include <nil/blueprint/macros.hpp>
+
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
@@ -65,9 +67,7 @@ namespace nil {
                     current_block = inst->getParent();
                     BOOST_LOG_TRIVIAL(debug) << "\t" << current_block->getNameOrAsOperand();
                 }
-                std::string str;
-                llvm::raw_string_ostream ss(str);
-                inst->print(ss);
+                LLVM_PRINT(inst, str);
                 BOOST_LOG_TRIVIAL(debug) << "\t\t" << str;
             }
         };

--- a/include/nil/blueprint/macros.hpp
+++ b/include/nil/blueprint/macros.hpp
@@ -1,0 +1,46 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2024 Alexander Evgin <aleasims@nil.foundation>
+//
+// MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//---------------------------------------------------------------------------//
+// @file This file defines some helpful macros, used in assigner.
+//---------------------------------------------------------------------------//
+
+#ifndef ZKLLVM_ASSIGNER_INCLUDE_NIL_BLUEPRINT_MACROS_HPP_
+#define ZKLLVM_ASSIGNER_INCLUDE_NIL_BLUEPRINT_MACROS_HPP_
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <string>
+
+/**
+ * @brief This macro calls `print` function of LLVM printable entity and stores result into
+ * created string with name `output`.
+ *
+ * @param obj object, which can be printed with `obj->print()`
+ * @param output name of the output string
+ */
+#define LLVM_PRINT(obj, output)            \
+    std::string output;                           \
+    llvm::raw_string_ostream ss_##output(output); \
+    obj->print(ss_##output);
+
+#endif    // ZKLLVM_ASSIGNER_INCLUDE_NIL_BLUEPRINT_MACROS_HPP_


### PR DESCRIPTION
This macro helps dumping LLVM entities to strings.