### PR TITLE
Tiny refactor of stack.hpp

### DIFF
--- a/include/nil/blueprint/assigner.hpp
+++ b/include/nil/blueprint/assigner.hpp
@@ -55,6 +55,7 @@
 #include <nil/blueprint/logger.hpp>
 #include <nil/blueprint/layout_resolver.hpp>
 #include <nil/blueprint/input_reader.hpp>
+#include <nil/blueprint/memory.hpp>
 #include <nil/blueprint/non_native_marshalling.hpp>
 #include <nil/blueprint/stack.hpp>
 #include <nil/blueprint/integers/addition.hpp>

--- a/include/nil/blueprint/input_reader.hpp
+++ b/include/nil/blueprint/input_reader.hpp
@@ -31,6 +31,7 @@
 #include "llvm/IR/Type.h"
 
 #include <nil/blueprint/layout_resolver.hpp>
+#include <nil/blueprint/memory.hpp>
 #include <nil/blueprint/signature_parser.hpp>
 #include <nil/blueprint/stack.hpp>
 #include <nil/blueprint/non_native_marshalling.hpp>

--- a/include/nil/blueprint/stack.hpp
+++ b/include/nil/blueprint/stack.hpp
@@ -46,8 +46,18 @@ namespace nil {
 
         template<typename VarType>
         struct stack_frame {
-            std::map<const llvm::Value *, VarType> scalars;
-            std::map<const llvm::Value *, std::vector<VarType>> vectors;
+            /// @brief Type representing scalar registers.
+            using scalar_regs = std::map<const llvm::Value *, VarType>;
+
+            /// @brief Type representing vector registers.
+            using vector_regs = std::map<const llvm::Value *, std::vector<VarType>>;
+
+            /// @brief Registers holding scalar values (integers, pointers, native fields).
+            scalar_regs scalars;
+
+            /// @brief Registers holding vector values (non-native fields, curves, vectors, etc.).
+            vector_regs vectors;
+
             const llvm::CallInst *caller;
         };
 

--- a/include/nil/blueprint/stack.hpp
+++ b/include/nil/blueprint/stack.hpp
@@ -26,24 +26,18 @@
 #ifndef CRYPTO3_ASSIGNER_STACK_HPP
 #define CRYPTO3_ASSIGNER_STACK_HPP
 
-#include <list>
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Value.h"
+
 #include <map>
-#include <variant>
-#include <stack>
-
-#include <llvm/IRReader/IRReader.h>
-#include <llvm/IR/LLVMContext.h>
-#include <llvm/Support/SourceMgr.h>
-#include <llvm/IR/Module.h>
-#include <llvm/IR/InstrTypes.h>
-#include <llvm/IR/Instructions.h>
-#include "llvm/IR/Constants.h"
-
-#include <nil/blueprint/memory.hpp>
+#include <vector>
 
 namespace nil {
     namespace blueprint {
-
+        /**
+         * @brief Execution frame. Each function call uses its own `stack_frame`, which holds
+         * local variables.
+         */
         template<typename VarType>
         struct stack_frame {
             /// @brief Type representing scalar registers.


### PR DESCRIPTION
- Added type aliases for "registers" in `stack_frame` (this will allow to easily reuse these types in the future)
- Removed some unused includes
- Added some docs for `stack_frame`